### PR TITLE
Add paypal links to the donate page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ release: downloadlinks changelog releasejs
 deploy: release
 	rsync --chown www-data:www-data -avz --delete --exclude 'forum/' --exclude 'codedoc/' docs/ pioneer:/var/www/pioneerspacesim.net/
 downloadlinks:
-	python make-downloadlinks.py > themes/pioneer/layouts/shortcodes/downloadlinks.html
+	python3 make-downloadlinks.py > themes/pioneer/layouts/shortcodes/downloadlinks.html
 changelog:
-	python make-changelog.py > themes/pioneer/layouts/shortcodes/changelog.html
+	python3 make-changelog.py > themes/pioneer/layouts/shortcodes/changelog.html
 releasejs:
-	python make-release-js.py > themes/pioneer/layouts/partials/releases.html
+	python3 make-release-js.py > themes/pioneer/layouts/partials/releases.html

--- a/themes/pioneer/layouts/_default/single.html
+++ b/themes/pioneer/layouts/_default/single.html
@@ -11,6 +11,11 @@
 								{{ .Content }}
 						</div>
 				</article>
+				{{ if eq .Title "Donate" }}
+				<aside class="support-twitter">
+						{{ partial "support.html" .}}
+				</aside>
+				{{ end }}
 				</div>
 				{{ partial "footer.html" .}}
     </body>

--- a/themes/pioneer/layouts/partials/support.html
+++ b/themes/pioneer/layouts/partials/support.html
@@ -10,9 +10,11 @@
 			<form method="post" action="https://www.paypal.com/cgi-bin/webscr" class="paypal-button" target="_blank"><input type="hidden" name="button" value="donate"><input type="hidden" name="item_name" value="Pioneer Space Sim - thank you!"><input type="hidden" name="currency_code" value="EUR"><input type="hidden" name="cmd" value="_donations"><input type="hidden" name="business" value="rob@eatenbyagrue.org"><input type="hidden" name="bn" value="JavaScriptButton_donate"><input type="hidden" name="env" value="www"><input type="image" src="{{$baseURL}}/currency_euro.png" width="32" height="32" alt="EUR"></form>
 			<form method="post" action="https://www.paypal.com/cgi-bin/webscr" class="paypal-button" target="_blank"><input type="hidden" name="button" value="donate"><input type="hidden" name="item_name" value="Pioneer Space Sim - thank you!"><input type="hidden" name="currency_code" value="GBP"><input type="hidden" name="cmd" value="_donations"><input type="hidden" name="business" value="rob@eatenbyagrue.org"><input type="hidden" name="bn" value="JavaScriptButton_donate"><input type="hidden" name="env" value="www"><input type="image" src="{{$baseURL}}/currency_pound.png" width="32" height="32" alt="GBP"></form>
   </div>
+  {{ if ne .Title "Donate" }}
   <p id='donate-text'>
     <a href='/page/donate/'>Why donate?</a>
   </p>
+  {{ end }}
   <script type="text/javascript" src="//static.flattr.net/button/button.js"></script>
   <script type="text/javascript">
 /* <![CDATA[ */


### PR DESCRIPTION
The donate page did not provide any links. It now shows the "support" right panel on the donate page.