### PR TITLE
Add analytics to page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test: downloadlinks changelog releasejs
-	hugo server -w -v --bind 0.0.0.0
+	hugo server -w --logLevel info --bind 0.0.0.0
 release: downloadlinks changelog releasejs
 	hugo
 deploy: release

--- a/config.toml
+++ b/config.toml
@@ -42,3 +42,7 @@ weight=15
 name="Community Discord"
 url="https://discord.gg/Xzwh5ZPFcK"
 weight=16
+
+[Params.umami]
+websiteId = "6a556223-cd99-4fe0-b309-166d8f234052"
+jsLocation = "https://analytics.pioneerspacesim.net/script.js"

--- a/themes/pioneer/layouts/partials/analytics.html
+++ b/themes/pioneer/layouts/partials/analytics.html
@@ -1,0 +1,6 @@
+<script
+  async
+  defer
+  data-website-id="{{ .Site.Params.umami.websiteId }}"
+  src="{{ .Site.Params.umami.jsLocation }}"
+  ></script>

--- a/themes/pioneer/layouts/partials/head.html
+++ b/themes/pioneer/layouts/partials/head.html
@@ -29,4 +29,5 @@
     <!-- <script src="{{ .Site.BaseURL }}/js/jquery.min.js"></script>
 				 <script src="{{ .Site.BaseURL }}/js/main.min.js">
 				 </script> -->
+    {{ partial "analytics.html" . }}
 </head>


### PR DESCRIPTION
It would be nice to see how much traffic we get to the site (and correlation with posts / announcements), and which countries (we used to be very "UK heavy", I suspect).

I already have an instance of [umami](https://umami.is/) running on the Pioneer box/VM, so I think embedding the tracking code is the last piece of the puzzle. 

I would have expected this PR to insert the tracking id in the header of each generated file, but grep tells me I'm not fully there (yet). Suggestions?

Code adapted from [chringel21](https://github.com/chringel21/chringel-hugo-theme/tree/main), and his [blog post](https://chringel.dev/2022/04/umami-a-google-analytics-alternative-for-hugo/)