### PR TITLE
Track download clicks

### DIFF
--- a/make-downloadlinks.py
+++ b/make-downloadlinks.py
@@ -14,7 +14,13 @@ with urllib.request.urlopen('https://api.github.com/repos/pioneerspacesim/pionee
         url = asset['browser_download_url']
         date = asset['updated_at'][0:10]
         size = "{0:.2f}".format(asset['size'] / 1024 / 1024)
-        print(f'<li><a href="{url}">{name}</a> ({date} · {size} MB)</li>')
+
+        label = "unknown"
+        for dist in {"linux", "win", "app"}:
+            if dist in name.lower():
+                label = dist
+
+        print(f'<li><a data-umami-event="Downloaded {date} ({label})" href="{url}">{name}</a> ({date} · {size} MB)</li>')
     print('</ul>')
     print(f'<p>{body}</p>')
 


### PR DESCRIPTION
This should (I hope) allow us to also see when and where download was initiated. (Umami [documentation](https://umami.is/docs/track-events))

Before:
```html
<ul>
<li><a href="https://github.com/pioneerspacesim/pioneer/releases/download/20240314/pioneer-20240314-win.exe">pioneer-20240314-win.exe</a> (2024-03-14 · 497.99 MB)</li>
<li><a href="https://github.com/pioneerspacesim/pioneer/releases/download/20240314/pioneer-linux-x64-20240314.tar.gz">pioneer-linux-x64-20240314.tar.gz</a> (2024-03-14 · 712.41 MB)</li>
<li><a href="https://github.com/pioneerspacesim/pioneer/releases/download/20240314/Pioneer-x86_64.AppImage">Pioneer-x86_64.AppImage</a> (2024-03-14 · 683.46 MB)</li>
</ul>
```
after:
```html
<ul>
<li><a data-umami-event="pioneer-20240314-win.exe" href="https://github.com/pioneerspacesim/pioneer/releases/download/20240314/pioneer-20240314-win.exe">pioneer-20240314-win.exe</a> (2024-03-14 · 497.99 MB)</li>
<li><a data-umami-event="pioneer-linux-x64-20240314.tar.gz" href="https://github.com/pioneerspacesim/pioneer/releases/download/20240314/pioneer-linux-x64-20240314.tar.gz">pioneer-linux-x64-20240314.tar.gz</a> (2024-03-14 · 712.41 MB)</li>
<li><a data-umami-event="Pioneer-x86_64.AppImage" href="https://github.com/pioneerspacesim/pioneer/releases/download/20240314/Pioneer-x86_64.AppImage">Pioneer-x86_64.AppImage</a> (2024-03-14 · 683.46 MB)</li>
</ul>
```

Should we name the tags something different than just the (full) file name? Seems a bit long as it now stands.
