### PR TITLE
Make links to github issues clickable in release notes & disable stale code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
-test: downloadlinks changelog
+test: downloadlinks
 	hugo server -w --logLevel info --bind 0.0.0.0
-release: downloadlinks changelog
+release: downloadlinks
 	hugo
 deploy: release
 	rsync --chown www-data:www-data -avz --delete --exclude 'forum/' --exclude 'codedoc/' docs/ pioneer:/var/www/pioneerspacesim.net/
 downloadlinks:
 	python3 make-downloadlinks.py > layouts/partials/generated/downloadlinks.html
-changelog:
-	python3 make-changelog.py > layouts/partials/generated/changelog.html
 
 # Unused
+changelog:
+	python3 make-changelog.py > layouts/partials/generated/changelog.html
 releasejs:
 	python3 make-release-js.py > layouts/partials/generated/releases.html

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-test: downloadlinks changelog releasejs
+test: downloadlinks changelog
 	hugo server -w --logLevel info --bind 0.0.0.0
-release: downloadlinks changelog releasejs
+release: downloadlinks changelog
 	hugo
 deploy: release
 	rsync --chown www-data:www-data -avz --delete --exclude 'forum/' --exclude 'codedoc/' docs/ pioneer:/var/www/pioneerspacesim.net/
@@ -8,5 +8,7 @@ downloadlinks:
 	python3 make-downloadlinks.py > layouts/partials/generated/downloadlinks.html
 changelog:
 	python3 make-changelog.py > layouts/partials/generated/changelog.html
+
+# Unused
 releasejs:
 	python3 make-release-js.py > layouts/partials/generated/releases.html

--- a/content/page/download.md
+++ b/content/page/download.md
@@ -24,4 +24,4 @@ See the [compiling guide](https://github.com/pioneerspacesim/pioneer/blob/master
 
 ## Changelog
 
-{{< changelog >}}
+For list of full development history, see [Changelog.txt](https://github.com/pioneerspacesim/pioneer/blob/master/Changelog.txt)

--- a/make-changelog.py
+++ b/make-changelog.py
@@ -1,3 +1,7 @@
+"""
+Generate changelog for latest month.
+"""
+
 #!/usr/bin/python
 import collections
 import re
@@ -7,6 +11,7 @@ firstline = True
 changelog = urllib.request.urlopen('https://raw.githubusercontent.com/pioneerspacesim/pioneer/master/Changelog.txt').read().decode('utf-8')
 for line in changelog.splitlines():
     if firstline:
+        # Get title: "Month YYYY"
         lines.append((0, line.strip()))
         firstline = False
     elif len(line) == 0:

--- a/make-downloadlinks.py
+++ b/make-downloadlinks.py
@@ -1,12 +1,19 @@
 #!/usr/bin/python
 import json
+import re
 import urllib.request
+
 import markdown
+
 with urllib.request.urlopen('https://api.github.com/repos/pioneerspacesim/pioneer/releases/latest') as json_file:
     latest = json.load(json_file)
     assets = latest['assets']
     title = latest['name']
     body = markdown.markdown(latest['body'])
+
+    # Make issue tags "(#<numbers>)" clickable
+    body = re.sub(r'#(\d+)', r'<a href="https://github.com/pioneerspacesim/pioneer/issues/\1">#\1</a>', body.strip().lstrip(' *'))
+
     print(f'<h4>Release: {title}</h4>')
     print('<ul>')
     for asset in assets:
@@ -23,4 +30,3 @@ with urllib.request.urlopen('https://api.github.com/repos/pioneerspacesim/pionee
         print(f'<li><a data-umami-event="Downloaded {date} ({label})" href="{url}">{name}</a> ({date} · {size} MB)</li>')
     print('</ul>')
     print(f'<p>{body}</p>')
-

--- a/make-release-js.py
+++ b/make-release-js.py
@@ -18,6 +18,9 @@ with urllib.request.urlopen('https://api.github.com/repos/pioneerspacesim/pionee
         elif "linux" in name:
             tag = "Lin64"
             name = "Linux 64"
+        elif "App" in name:
+            tag = "App"
+            name = "App Image Linux 64"
         else:
             tag = "Unk"
             name = "Unknown"


### PR DESCRIPTION
See commit comments.

Possibly we'd like to remove the unused scripts altogether.