### PR TITLE
Replace twitter embed with mastodon feed

### DIFF
--- a/themes/pioneer/layouts/index.html
+++ b/themes/pioneer/layouts/index.html
@@ -1,24 +1,24 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en-us">
-		{{ partial "head.html" . }}
-		<body>
-				{{ partial "menu.html" . }}
-				{{ partial "banner.html" . }}
+	{{ partial "head.html" . }}
+	<body>
+		{{ partial "menu.html" . }}
+		{{ partial "banner.html" . }}
 
-				<div class="main">
-						<article class="content">
-								<div class="box">
-										{{.Content }}
-										{{ partial "carousel.html" . }}
-								</div>
-						</article>
-						<aside class="support-twitter">
-								{{ partial "download-button.html" .}}
-								{{ partial "support.html" .}}
-								{{ partial "twitter.html" .}}
-						</aside>
+		<div class="main">
+			<article class="content">
+				<div class="box">
+					{{.Content }}
+					{{ partial "carousel.html" . }}
 				</div>
+			</article>
+			<aside class="support-twitter">
+				{{ partial "download-button.html" .}}
+				{{ partial "support.html" .}}
+				{{ partial "mastodon.html" .}}
+			</aside>
+		</div>
 
-				{{ partial "footer.html" .}}
+		{{ partial "footer.html" .}}
     </body>
 </html>

--- a/themes/pioneer/layouts/partials/head.html
+++ b/themes/pioneer/layouts/partials/head.html
@@ -12,6 +12,13 @@
 		<link rel="stylesheet" type="text/css" href="{{$baseURL}}/css/video-js.min.css"/>
 	  <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Orbitron">
     <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Titillium+Web">
+
+    <!-- Mastodon feed embed -->
+    {{ if .IsHome }}
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@idotj/mastodon-embed-timeline@4.4.2/dist/mastodon-timeline.min.css" integrity="sha256-1UGgxsonaMCfOEnVOL89aMKSo3GEAmaRP0ISbsWa6lU=" crossorigin="anonymous">
+    <script src="https://cdn.jsdelivr.net/npm/@idotj/mastodon-embed-timeline@4.4.2/dist/mastodon-timeline.umd.js" integrity="sha256-E6WPG6iq+qQIzvu3HPJJxoAeRdum5siq13x4ITjyxu8=" crossorigin="anonymous"></script>
+    {{ end }}
+
     <!-- CSS -->
     <!-- <link rel="stylesheet" type="text/css" href="{{ .Site.BaseURL }}/css/uno.min.css" />
 				 <link rel="stylesheet" type="text/css" href="{{ .Site.BaseURL }}/css/lightGallery.css" /> -->

--- a/themes/pioneer/layouts/partials/mastodon.html
+++ b/themes/pioneer/layouts/partials/mastodon.html
@@ -1,0 +1,19 @@
+<section class="mastodon-wrapper">
+	<script>
+	window.addEventListener("load", () => {
+		const timeline = new MastodonTimeline.Init({
+			instanceUrl: "https://mstdn.games",
+			timelineType: "profile",
+			userId: "109791326094338766",
+			profileName: "@pioneerspacesim",
+      hideReplies: true,
+		});
+	});
+	</script>
+
+	<div id="mt-container" class="mt-container">
+		<div class="mt-body" role="feed">
+			<div class="mt-loading-spinner"></div>
+		</div>
+	</div>
+</section>

--- a/themes/pioneer/layouts/partials/twitter.html
+++ b/themes/pioneer/layouts/partials/twitter.html
@@ -1,5 +1,0 @@
-<section class="twitter">
-<h3>What's happening</h3>
-<a class="twitter-timeline" data-dnt="true" href="https://twitter.com/pioneerspacesim" data-widget-id="641610594513231872">Tweets by @pioneerspacesim</a>
-<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
-</section>

--- a/themes/pioneer/static/css/pioneer.css
+++ b/themes/pioneer/static/css/pioneer.css
@@ -27,12 +27,26 @@ a {
 		font-weight: bold;
 		flex: 0 0 auto;
 }
-h1,h2,h3,h4,h5 {
-				font-family: Orbitron, sans serif;
+
+/* Basic font setup */
+h1 {
+	font-size: 2.5rem;
 }
 h2 {
-		font-size: 120%;
+	font-size: 2rem;
 }
+h3 {
+	font-size: 1.5rem;
+}
+h4 {
+	font-size: 1rem;
+}
+h1,h2,h3,h4,h5 {
+	font-family: Orbitron, sans serif;
+	margin: 0.5em 0;
+}
+
+
 #banner {
 		padding: 10px;
 		margin: 0;
@@ -84,6 +98,16 @@ h2 {
 .support-twitter {
 		padding: 0 10px;
 		flex: 0 0 20%;
+		align-self: stretch;
+		margin-bottom: 1em;
+
+		display: flex;
+		flex-direction: column;
+}
+.support-twitter .mastodon-wrapper {
+	flex: 1 0 1px; /* flex-basis of 1px required to trigger overflow */
+	overflow-y: hidden;
+	font-size: 0.9rem;
 }
 #topmenu ul {
 		list-style-type: none;
@@ -142,10 +166,6 @@ h2 {
 
 #topmenu input[type=checkbox]:checked ~ #menu {
 		display: block;
-}
-.support h3, .twitter h3 {
-		font-family: Orbitron, sans serif;
-		font-size: 200%;
 }
 
 .paypal-button {


### PR DESCRIPTION
Twitter (now X) has severely restricted external visibility of tweets, rendering our embedded twitter feed entirely defunct.

This PR replaces that feed with https://gitlab.com/idotj/mastodon-embed-timeline, pointing to our mstdn.games account.

I've also made some minor font tweaks etc. to improve the layout, look, and consistency of the page slightly.